### PR TITLE
Add reload-all toggle and Firefox MV3 fallback

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,8 @@
     }
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
   },
   "action": {
     "default_popup": "popup.html",

--- a/popup.css
+++ b/popup.css
@@ -93,6 +93,23 @@ h1 {
   color: #fff;
 }
 
+.options {
+  margin-top: 8px;
+  margin-bottom: 6px;
+  font-size: 0.8rem;
+  color: #bbb;
+}
+.option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  user-select: none;
+}
+.option input {
+  accent-color: var(--accent);
+}
+
 .footer {
   margin-top: 8px;
   text-align: center;

--- a/popup.html
+++ b/popup.html
@@ -14,6 +14,12 @@
       <button id="saveBtn">Save</button>
     </div>
     <ul id="accountsList"></ul>
+    <div class="options">
+      <label class="option">
+        <input id="reloadAllTabs" type="checkbox"/>
+        Reload all Reddit tabs on switch
+      </label>
+    </div>
     <div class="footer">
       <div class="footer-text">
         Drag ≡ to reorder<br/>

--- a/popup.js
+++ b/popup.js
@@ -6,13 +6,19 @@ const modal      = document.getElementById("editModal"),
       editInput  = document.getElementById("editInput"),
       confirmBtn = document.getElementById("confirmEdit"),
       cancelBtn  = document.getElementById("cancelEdit"),
-      list       = document.getElementById("accountsList");
+      list       = document.getElementById("accountsList"),
+      reloadAllTabsToggle = document.getElementById("reloadAllTabs");
 
 document.addEventListener("DOMContentLoaded", async () => {
   await initCrypto();
   document.getElementById("saveBtn").onclick = saveAccount;
   confirmBtn.onclick = applyEdit;
   cancelBtn.onclick  = () => modal.classList.add("hidden");
+  const { reloadAllTabs = true } = await chrome.storage.local.get("reloadAllTabs");
+  reloadAllTabsToggle.checked = reloadAllTabs;
+  reloadAllTabsToggle.onchange = async () => {
+    await chrome.storage.local.set({ reloadAllTabs: reloadAllTabsToggle.checked });
+  };
   loadAccounts();
 });
 

--- a/reload.js
+++ b/reload.js
@@ -1,6 +1,8 @@
 // reload.js — runs on reddit.com pages
-chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === "local" && changes.lastSwitched) {
+chrome.storage.onChanged.addListener(async (changes, area) => {
+  if (area !== "local" || !changes.lastSwitched) return;
+  const { reloadAllTabs = true } = await chrome.storage.local.get("reloadAllTabs");
+  if (reloadAllTabs || document.visibilityState === "visible") {
     window.location.reload();
   }
 });


### PR DESCRIPTION
**Summary**
Adds a user-facing toggle to control whether all Reddit tabs reload on account switch, and adds a Firefox MV3 background fallback so the add-on can load as a temporary extension.

**Changes**
- Added “Reload all Reddit tabs on switch” checkbox to the popup, persisted in `chrome.storage.local`.
- Updated reload behavior to respect the toggle (reload all tabs or only the active visible tab).
- Added `background.scripts` alongside `background.service_worker` for Firefox MV3 compatibility.

**Testing**
1. Load as temporary add-on in Firefox.
2. Open multiple Reddit tabs.
3. Toggle “Reload all Reddit tabs on switch” ON: all loaded Reddit tabs reload after switch.
4. Toggle OFF: only the visible Reddit tab reloads after switch.

**Notes**
Default behavior remains “reload all” to preserve existing expectations.
